### PR TITLE
Add expense type filtering by date

### DIFF
--- a/src/features/home/api/list-expenses-by-type.ts
+++ b/src/features/home/api/list-expenses-by-type.ts
@@ -1,0 +1,17 @@
+import { httpGet } from "@/services/api/http";
+
+export async function listExpensesByType(
+  typeId: string,
+  month: number,
+  year: number,
+): Promise<any> {
+  try {
+    const API_URL = `types/${typeId}/expenses/${month}/${year}`;
+
+    const response: any = await httpGet(API_URL);
+
+    return response;
+  } catch (error) {
+    throw new Error("Falha ao buscar as despesas do tipo");
+  }
+}

--- a/src/features/home/api/list-expenses-per-type.ts
+++ b/src/features/home/api/list-expenses-per-type.ts
@@ -1,0 +1,16 @@
+import { httpGet } from "@/services/api/http";
+
+export async function listExpensesPerType(
+  month: number,
+  year: number
+): Promise<any> {
+  try {
+    const API_URL = `types/top-expenses/${month}/${year}`;
+
+    const response: any = await httpGet(API_URL);
+
+    return response;
+  } catch (error) {
+    throw new Error("Falha ao buscar as despesas por tipo");
+  }
+}

--- a/src/features/home/components/ExpensePerType.tsx
+++ b/src/features/home/components/ExpensePerType.tsx
@@ -8,46 +8,59 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
-import { HandCoins } from "lucide-react";
-import { listTopCategories } from "../api/list-top-categories";
+import { HandCoins, SearchIcon } from "lucide-react";
+import { listExpensesPerType } from "../api/list-expenses-per-type";
+import { MonthSelect } from "@/components/common/month-select";
+import { YearSelect } from "@/components/common/year-select";
+import { Button } from "@/components/ui/button";
 
-export default function BalanceCard() {
-  const [categories, setCategories] = useState<any[]>([]);
+export default function ExpensePerType() {
+  const [types, setTypes] = useState<any[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  useEffect(() => {
-    const fetchCategories = async () => {
-      try {
-        setIsLoading(true);
-        const data = await listTopCategories();
-        setCategories(data);
-      } catch (error) {
-        console.error("Erro ao carregar os dados:", error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
+  const [month, setMonth] = useState<number>(new Date().getMonth() + 1);
+  const [year, setYear] = useState<number>(new Date().getFullYear());
 
-    fetchCategories();
+  const fetchTypes = async () => {
+    try {
+      setIsLoading(true);
+      const data = await listExpensesPerType(month, year);
+      setTypes(data);
+    } catch (error) {
+      console.error("Erro ao carregar os dados:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchTypes();
   }, []);
   return (
     <div>
+      <div className="flex justify-end gap-2 mb-2">
+        <MonthSelect month={month} setMonth={setMonth} />
+        <YearSelect year={year} setYear={setYear} />
+        <Button variant="outline" onClick={fetchTypes}>
+          <SearchIcon className="w-4 h-4" /> Buscar
+        </Button>
+      </div>
       <Card>
         <CardHeader>
           <CardTitle className="flex justify-between">
-            Categorias <HandCoins className="w-4 h-4" />
+            Tipos <HandCoins className="w-4 h-4" />
           </CardTitle>
-          <CardDescription>Categorias mais gastas</CardDescription>
+          <CardDescription>Despesas por tipo</CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
-          {categories.map((category, index) => (
+          {types.map((type, index) => (
             <div className="space-y-2" key={index}>
               <div className="flex items-center justify-between">
                 <span className="text-sm text-muted-foreground">
-                  {category.description}
+                  {type.description}
                 </span>
-                <span className="text-sm">R$ {category.total_expenses}</span>
+                <span className="text-sm">R$ {type.total_expenses}</span>
               </div>
-              <Progress value={category.percentage} />
+              <Progress value={type.percentage} />
             </div>
           ))}
         </CardContent>

--- a/src/features/home/components/ExpensePerType.tsx
+++ b/src/features/home/components/ExpensePerType.tsx
@@ -10,6 +10,8 @@ import {
 import { Progress } from "@/components/ui/progress";
 import { HandCoins, SearchIcon } from "lucide-react";
 import { listExpensesPerType } from "../api/list-expenses-per-type";
+import { listExpensesByType } from "../api/list-expenses-by-type";
+import Loader from "@/components/common/loading";
 import { MonthSelect } from "@/components/common/month-select";
 import { YearSelect } from "@/components/common/year-select";
 import { Button } from "@/components/ui/button";
@@ -19,6 +21,9 @@ export default function ExpensePerType() {
   const [isLoading, setIsLoading] = useState(true);
   const [month, setMonth] = useState<number>(new Date().getMonth() + 1);
   const [year, setYear] = useState<number>(new Date().getFullYear());
+  const [selectedType, setSelectedType] = useState<any | null>(null);
+  const [typeExpenses, setTypeExpenses] = useState<any[]>([]);
+  const [isTypeLoading, setIsTypeLoading] = useState(false);
 
   const fetchTypes = async () => {
     try {
@@ -29,6 +34,19 @@ export default function ExpensePerType() {
       console.error("Erro ao carregar os dados:", error);
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  const fetchTypeExpenses = async (type: any) => {
+    try {
+      setIsTypeLoading(true);
+      setSelectedType(type);
+      const data = await listExpensesByType(type.id, month, year);
+      setTypeExpenses(data);
+    } catch (error) {
+      console.error("Erro ao carregar as despesas:", error);
+    } finally {
+      setIsTypeLoading(false);
     }
   };
 
@@ -53,7 +71,11 @@ export default function ExpensePerType() {
         </CardHeader>
         <CardContent className="space-y-6">
           {types.map((type, index) => (
-            <div className="space-y-2" key={index}>
+            <div
+              className="space-y-2 cursor-pointer"
+              key={index}
+              onClick={() => fetchTypeExpenses(type)}
+            >
               <div className="flex items-center justify-between">
                 <span className="text-sm text-muted-foreground">
                   {type.description}
@@ -63,6 +85,29 @@ export default function ExpensePerType() {
               <Progress value={type.percentage} />
             </div>
           ))}
+
+          {selectedType && (
+            <div className="pt-4 space-y-2">
+              <h4 className="font-medium">
+                Total no mês: R$ {selectedType.total_expenses}
+              </h4>
+              {isTypeLoading ? (
+                <Loader />
+              ) : (
+                <ul className="space-y-1">
+                  {typeExpenses.map((expense, idx) => (
+                    <li
+                      key={idx}
+                      className="flex items-center justify-between text-sm"
+                    >
+                      <span>{expense.expense}</span>
+                      <span>R$ {expense.amount}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- implement API call for expense data per type with month/year parameters
- update ExpensePerType component to allow selecting month and year and fetching data

## Testing
- `npm run lint` *(fails: prompts to set up ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_685c5f40301c8320b5901a0f13450d3e