### PR TITLE
Fix route order for expense type API and add type selector

### DIFF
--- a/src/components/common/type-select.tsx
+++ b/src/components/common/type-select.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useData } from "@/context/DataContext";
+
+export function TypeSelect({
+  typeId,
+  setTypeId,
+}: {
+  typeId: string;
+  setTypeId: (value: string) => void;
+}) {
+  const { types } = useData();
+  return (
+    <Select onValueChange={(value) => setTypeId(value)} value={typeId}>
+      <SelectTrigger className="w-[180px]">
+        <SelectValue placeholder="Selecione um tipo" />
+      </SelectTrigger>
+      <SelectContent>
+        {types.map((type) => (
+          <SelectItem key={type.id} value={type.id}>
+            {type.type}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/features/home/api/list-expenses-by-type.ts
+++ b/src/features/home/api/list-expenses-by-type.ts
@@ -6,7 +6,7 @@ export async function listExpensesByType(
   year: number,
 ): Promise<any> {
   try {
-    const API_URL = `types/${typeId}/expenses/${month}/${year}`;
+    const API_URL = `types/${typeId}/expenses/${year}/${month}`;
 
     const response: any = await httpGet(API_URL);
 

--- a/src/features/home/api/list-expenses-per-type.ts
+++ b/src/features/home/api/list-expenses-per-type.ts
@@ -5,7 +5,7 @@ export async function listExpensesPerType(
   year: number
 ): Promise<any> {
   try {
-    const API_URL = `types/top-expenses/${month}/${year}`;
+    const API_URL = `types/top-expenses/${year}/${month}`;
 
     const response: any = await httpGet(API_URL);
 

--- a/src/features/home/components/ExpensePerType.tsx
+++ b/src/features/home/components/ExpensePerType.tsx
@@ -14,6 +14,7 @@ import { listExpensesByType } from "../api/list-expenses-by-type";
 import Loader from "@/components/common/loading";
 import { MonthSelect } from "@/components/common/month-select";
 import { YearSelect } from "@/components/common/year-select";
+import { TypeSelect } from "@/components/common/type-select";
 import { Button } from "@/components/ui/button";
 
 export default function ExpensePerType() {
@@ -24,6 +25,7 @@ export default function ExpensePerType() {
   const [selectedType, setSelectedType] = useState<any | null>(null);
   const [typeExpenses, setTypeExpenses] = useState<any[]>([]);
   const [isTypeLoading, setIsTypeLoading] = useState(false);
+  const [selectedTypeId, setSelectedTypeId] = useState<string>("");
 
   const fetchTypes = async () => {
     try {
@@ -50,12 +52,21 @@ export default function ExpensePerType() {
     }
   };
 
+  const handleTypeChange = (value: string) => {
+    setSelectedTypeId(value);
+    const type = types.find((t) => t.id === value);
+    if (type) {
+      fetchTypeExpenses(type);
+    }
+  };
+
   useEffect(() => {
     fetchTypes();
   }, []);
   return (
     <div>
       <div className="flex justify-end gap-2 mb-2">
+        <TypeSelect typeId={selectedTypeId} setTypeId={handleTypeChange} />
         <MonthSelect month={month} setMonth={setMonth} />
         <YearSelect year={year} setYear={setYear} />
         <Button variant="outline" onClick={fetchTypes}>


### PR DESCRIPTION
## Summary
- adjust expense-by-type API routes to match backend order
- add a TypeSelect component
- let ExpensePerType filter using TypeSelect

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_685c65d3384c8320b435530b512bb978