### PR TITLE
Add targets tab and extend TabsList style

### DIFF
--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -14,7 +14,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+      "inline-flex h-9 w-full items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
       className
     )}
     {...props}

--- a/src/features/home/components/HomePage.tsx
+++ b/src/features/home/components/HomePage.tsx
@@ -1,18 +1,25 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import TopCards from "./TopCards";
+import ObjectiveList from "@/features/objective/components/ObjectiveList";
 
 export default function HomePage() {
   return (
     <div>
       <Tabs defaultValue="home">
-        <TabsList>
-          <TabsTrigger value="home">Visão Geral</TabsTrigger>
-          <TabsTrigger value="password">types</TabsTrigger>
+        <TabsList className="w-full">
+          <TabsTrigger className="flex-1" value="home">
+            Visão Geral
+          </TabsTrigger>
+          <TabsTrigger className="flex-1" value="targets">
+            Metas
+          </TabsTrigger>
         </TabsList>
         <TabsContent value="home">
           <TopCards />
         </TabsContent>
-        <TabsContent value="types">Change your password here.</TabsContent>
+        <TabsContent value="targets">
+          <ObjectiveList />
+        </TabsContent>
       </Tabs>
     </div>
   );

--- a/src/features/objective/components/ObjectiveList.tsx
+++ b/src/features/objective/components/ObjectiveList.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { getObjectives } from "@/features/objective/api/get-objectives";
+import { columns } from "./ObjectiveColumns";
+import { DataTable } from "./ObjectiveDataTable";
+import Loader from "@/components/common/loading";
+
+export default function ObjectiveList() {
+  const [objectives, setObjectives] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchObjectives = async () => {
+      try {
+        setIsLoading(true);
+        const data = await getObjectives();
+        setObjectives(data);
+      } catch (error) {
+        console.error("Erro ao carregar os dados:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchObjectives();
+  }, []);
+
+  const reloadObjectives = async () => {
+    try {
+      const data = await getObjectives();
+      setObjectives(data);
+    } catch (error) {
+      console.error("Error reloading objectives:", error);
+    }
+  };
+
+  return (
+    <div>
+      {isLoading ? (
+        <Loader />
+      ) : (
+        <DataTable
+          columns={columns}
+          data={objectives}
+          reloadObjectives={reloadObjectives}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend TabsList with full width styling
- add a new ObjectiveList component to fetch and display targets
- expose a `Metas` tab in the home page with the new list

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685c674a3d4c8320b85b993d5319d385