### PR TITLE
Add parameters to top categories API

### DIFF
--- a/src/features/home/api/list-top-categories.ts
+++ b/src/features/home/api/list-top-categories.ts
@@ -1,8 +1,12 @@
 import { httpGet } from "@/services/api/http";
 
-export async function listTopCategories(): Promise<any> {
+export async function listTopCategories(
+  limit: number,
+  month: number,
+  year: number,
+): Promise<any> {
   try {
-    const API_URL = "categories/top-expenses/6/2025";
+    const API_URL = `categories/top-expenses/${limit}/${year}/${month}`;
 
     const response: any = await httpGet(API_URL);
 

--- a/src/features/home/components/CategoriesCard.tsx
+++ b/src/features/home/components/CategoriesCard.tsx
@@ -8,29 +8,42 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
-import { HandCoins } from "lucide-react";
+import { HandCoins, SearchIcon } from "lucide-react";
 import { listTopCategories } from "../api/list-top-categories";
+import { MonthSelect } from "@/components/common/month-select";
+import { YearSelect } from "@/components/common/year-select";
+import { Button } from "@/components/ui/button";
 
 export default function BalanceCard() {
   const [categories, setCategories] = useState<any[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  useEffect(() => {
-    const fetchCategories = async () => {
-      try {
-        setIsLoading(true);
-        const data = await listTopCategories();
-        setCategories(data);
-      } catch (error) {
-        console.error("Erro ao carregar os dados:", error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
+  const [month, setMonth] = useState<number>(new Date().getMonth() + 1);
+  const [year, setYear] = useState<number>(new Date().getFullYear());
+  const [limit] = useState<number>(6);
+  const fetchCategories = async () => {
+    try {
+      setIsLoading(true);
+      const data = await listTopCategories(limit, month, year);
+      setCategories(data);
+    } catch (error) {
+      console.error("Erro ao carregar os dados:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
+  useEffect(() => {
     fetchCategories();
   }, []);
   return (
     <div>
+      <div className="flex justify-end gap-2 mb-2">
+        <MonthSelect month={month} setMonth={setMonth} />
+        <YearSelect year={year} setYear={setYear} />
+        <Button variant="outline" onClick={fetchCategories}>
+          <SearchIcon className="w-4 h-4" /> Buscar
+        </Button>
+      </div>
       <Card>
         <CardHeader>
           <CardTitle className="flex justify-between">


### PR DESCRIPTION
## Summary
- make `listTopCategories` accept limit, month and year parameters
- allow `CategoriesCard` to select month/year and reload categories

## Testing
- `npm run lint` *(fails: prompts about ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_685c69b520d4832080b2830f841163a6