### PR TITLE
Switch forms to dialogs with consistent layout

### DIFF
--- a/src/features/card/components/CardCreateForm.tsx
+++ b/src/features/card/components/CardCreateForm.tsx
@@ -2,12 +2,14 @@
 
 import React, { useState } from 'react';
 import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from '@/components/ui/sheet';
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogClose,
+} from '@/components/ui/dialog';
 import {
   Form,
   FormControl,
@@ -26,7 +28,6 @@ import { Card } from '../types/card';
 import { toast } from 'sonner';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { CirclePlus } from 'lucide-react';
 import CreateButton from '@/components/common/create-button';
 
 const formSchema = z.object({
@@ -44,7 +45,7 @@ export default function CreateForm({
 }: {
   onCardCreated: () => void;
 }) {
-  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -64,19 +65,21 @@ export default function CreateForm({
 
     onCardCreated();
 
-    setIsSheetOpen(false);
+    setIsDialogOpen(false);
   }
 
   return (
-    <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
-      <SheetTrigger asChild>
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DialogTrigger asChild>
         <CreateButton />
-      </SheetTrigger>
-      <SheetContent className="w-[500px] max-h-screen overflow-y-auto p-4">
-        <SheetHeader>
-          <SheetTitle>Cadastro de Cartão</SheetTitle>
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+      </DialogTrigger>
+      <DialogContent className="max-w-[1200px] max-h-screen overflow-y-auto p-4">
+        <DialogHeader>
+          <DialogTitle>Cadastro de Cartão</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <div className="grid grid-cols-2 gap-4">
               <FormField
                 control={form.control}
                 name="card"
@@ -131,18 +134,16 @@ export default function CreateForm({
                   </FormItem>
                 )}
               />
-              <Button
-                type="submit"
-                className="bg-green-600 rounded-full p-2 mr-2"
-              >
-                <p className="flex text-white font-medium">
-                  <CirclePlus color="#ffffff" height={20} /> Cadastrar
-                </p>
-              </Button>
-            </form>
-          </Form>
-        </SheetHeader>
-      </SheetContent>
-    </Sheet>
+            </div>
+            <DialogFooter className="flex justify-end items-center">
+              <DialogClose asChild>
+                <Button variant={"outline"}>Cancelar</Button>
+              </DialogClose>
+              <Button type="submit">Cadastrar</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/features/card/components/CardEditForm.tsx
+++ b/src/features/card/components/CardEditForm.tsx
@@ -2,12 +2,14 @@
 
 import React, { useState } from 'react';
 import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from '@/components/ui/sheet';
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogClose,
+} from '@/components/ui/dialog';
 import {
   Form,
   FormControl,
@@ -25,7 +27,6 @@ import { editCard } from '../api/edit-card';
 import { useToast } from '@/hooks/use-toast';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Pencil } from 'lucide-react';
 import { Switch } from '@/components/ui/switch';
 import EditButton from '@/components/common/edit-button';
 
@@ -48,7 +49,7 @@ export default function EditForm({
   cardId: string;
   reloadCards?: () => void;
 }) {
-  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
   const { toast } = useToast();
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -72,19 +73,21 @@ export default function EditForm({
 
     reloadCards?.();
 
-    setIsSheetOpen(false);
+    setIsDialogOpen(false);
   }
 
   return (
-    <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
-      <SheetTrigger asChild>
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DialogTrigger asChild>
         <EditButton />
-      </SheetTrigger>
-      <SheetContent className="w-[500px] max-h-screen overflow-y-auto p-4">
-        <SheetHeader>
-          <SheetTitle>Editar Cartão</SheetTitle>
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+      </DialogTrigger>
+      <DialogContent className="max-w-[1200px] max-h-screen overflow-y-auto p-4">
+        <DialogHeader>
+          <DialogTitle>Editar Cartão</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <div className="grid grid-cols-2 gap-4">
               <FormField
                 control={form.control}
                 name="card"
@@ -139,18 +142,16 @@ export default function EditForm({
                   </FormItem>
                 )}
               />
-              <Button
-                type="submit"
-                className="bg-blue-600 rounded-full p-2 mr-2"
-              >
-                <p className="flex text-white font-medium">
-                  <Pencil color="#ffffff" height={15} /> Editar
-                </p>
-              </Button>
-            </form>
-          </Form>
-        </SheetHeader>
-      </SheetContent>
-    </Sheet>
+            </div>
+            <DialogFooter className="flex justify-end items-center">
+              <DialogClose asChild>
+                <Button variant={"outline"}>Cancelar</Button>
+              </DialogClose>
+              <Button type="submit">Editar</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/features/category/components/CategoryCreateForm.tsx
+++ b/src/features/category/components/CategoryCreateForm.tsx
@@ -2,12 +2,14 @@
 
 import React, { useState } from 'react';
 import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from '@/components/ui/sheet';
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogClose,
+} from '@/components/ui/dialog';
 import {
   Form,
   FormControl,
@@ -23,7 +25,6 @@ import { useForm } from 'react-hook-form';
 import { createCategory } from '../api/create-category';
 import { Category } from '../types/category';
 import { toast } from 'sonner';
-import { CirclePlus } from 'lucide-react';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import CreateButton from '@/components/common/create-button';
@@ -42,7 +43,7 @@ export default function CreateForm({
 }: {
   onCategoryCreated: () => void;
 }) {
-  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -61,19 +62,21 @@ export default function CreateForm({
 
     onCategoryCreated();
 
-    setIsSheetOpen(false);
+    setIsDialogOpen(false);
   }
 
   return (
-    <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
-      <SheetTrigger asChild>
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DialogTrigger asChild>
         <CreateButton />
-      </SheetTrigger>
-      <SheetContent className="w-[500px] max-h-screen overflow-y-auto p-4">
-        <SheetHeader>
-          <SheetTitle>Cadastro de Categoria</SheetTitle>
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+      </DialogTrigger>
+      <DialogContent className="max-w-[1200px] max-h-screen overflow-y-auto p-4">
+        <DialogHeader>
+          <DialogTitle>Cadastro de Categoria</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <div className="grid grid-cols-2 gap-4">
               <FormField
                 control={form.control}
                 name="category"
@@ -106,18 +109,16 @@ export default function CreateForm({
                   </FormItem>
                 )}
               />
-              <Button
-                type="submit"
-                className="bg-green-600 rounded-full p-2 mr-2"
-              >
-                <p className="flex text-white font-medium">
-                  <CirclePlus color="#ffffff" height={20} /> Cadastrar
-                </p>
-              </Button>
-            </form>
-          </Form>
-        </SheetHeader>
-      </SheetContent>
-    </Sheet>
+            </div>
+            <DialogFooter className="flex justify-end items-center">
+              <DialogClose asChild>
+                <Button variant={"outline"}>Cancelar</Button>
+              </DialogClose>
+              <Button type="submit">Cadastrar</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/features/category/components/CategoryEditForm.tsx
+++ b/src/features/category/components/CategoryEditForm.tsx
@@ -2,12 +2,14 @@
 
 import React, { useState } from 'react';
 import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from '@/components/ui/sheet';
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogClose,
+} from '@/components/ui/dialog';
 import {
   Form,
   FormControl,
@@ -25,7 +27,6 @@ import { editCategory } from '../api/edit-category';
 import { useToast } from '@/hooks/use-toast';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Pencil } from 'lucide-react';
 import EditButton from '@/components/common/edit-button';
 
 const formSchema = z.object({
@@ -46,7 +47,7 @@ export default function EditForm({
   categoryId: string;
   reloadCategories?: () => void;
 }) {
-  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
   const { toast } = useToast();
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -69,19 +70,21 @@ export default function EditForm({
 
     reloadCategories?.();
 
-    setIsSheetOpen(false);
+    setIsDialogOpen(false);
   }
 
   return (
-    <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
-      <SheetTrigger asChild>
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DialogTrigger asChild>
         <EditButton />
-      </SheetTrigger>
-      <SheetContent className="w-[500px] max-h-screen overflow-y-auto p-4">
-        <SheetHeader>
-          <SheetTitle>Editar Categoria</SheetTitle>
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+      </DialogTrigger>
+      <DialogContent className="max-w-[1200px] max-h-screen overflow-y-auto p-4">
+        <DialogHeader>
+          <DialogTitle>Editar Categoria</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <div className="grid grid-cols-2 gap-4">
               <FormField
                 control={form.control}
                 name="category"
@@ -114,18 +117,16 @@ export default function EditForm({
                   </FormItem>
                 )}
               />
-              <Button
-                type="submit"
-                className="bg-blue-600 rounded-full p-2 mr-2"
-              >
-                <p className="flex text-white font-medium">
-                  <Pencil color="#ffffff" height={15} /> Editar
-                </p>
-              </Button>
-            </form>
-          </Form>
-        </SheetHeader>
-      </SheetContent>
-    </Sheet>
+            </div>
+            <DialogFooter className="flex justify-end items-center">
+              <DialogClose asChild>
+                <Button variant={"outline"}>Cancelar</Button>
+              </DialogClose>
+              <Button type="submit">Editar</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/features/expense/components/ExpenseCreateForm.tsx
+++ b/src/features/expense/components/ExpenseCreateForm.tsx
@@ -66,7 +66,7 @@ export default function CreateForm({
   const { categories } = useCategories();
   const { types } = useTypes();
   const { cards } = useCards();
-  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -115,20 +115,20 @@ export default function CreateForm({
 
     onExpenseCreated();
 
-    setIsSheetOpen(false);
+    setIsDialogOpen(false);
   }
 
   return (
-    <Dialog open={isSheetOpen} onOpenChange={setIsSheetOpen}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-        <DialogTrigger asChild>
-          <CreateButton />
-        </DialogTrigger>
-        <DialogContent className="max-w-[1000px] max-h-screen overflow-y-auto p-4">
-          <DialogHeader>
-            <DialogTitle>Cadastro de Despesa</DialogTitle>
-          </DialogHeader>
-          <Form {...form}>
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DialogTrigger asChild>
+        <CreateButton />
+      </DialogTrigger>
+      <DialogContent className="max-w-[1200px] max-h-screen overflow-y-auto p-4">
+        <DialogHeader>
+          <DialogTitle>Cadastro de Despesa</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
             <div className="grid grid-cols-2 gap-4">
               <FormField
                 control={form.control}
@@ -307,9 +307,9 @@ export default function CreateForm({
               </DialogClose>
               <Button type="submit">Cadastrar</Button>
             </DialogFooter>
-          </Form>
-        </DialogContent>
-      </form>
+          </form>
+        </Form>
+      </DialogContent>
     </Dialog>
   );
 }

--- a/src/features/expense/components/ExpenseEditForm.tsx
+++ b/src/features/expense/components/ExpenseEditForm.tsx
@@ -2,12 +2,14 @@
 
 import React, { useState } from 'react';
 import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from '@/components/ui/sheet';
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogClose,
+} from '@/components/ui/dialog';
 import {
   Form,
   FormControl,
@@ -33,7 +35,6 @@ import { useCards } from '@/context/CardsContext';
 import { Expense } from '../types/expense';
 import { editExpense } from '../api/edit-expense';
 import { useToast } from '@/hooks/use-toast';
-import { Pencil } from 'lucide-react';
 import MoneyInput from '@/components/common/money-input';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -67,7 +68,7 @@ export default function EditForm({
   const { categories } = useCategories();
   const { types } = useTypes();
   const { cards } = useCards();
-  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
   const { toast } = useToast();
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -96,7 +97,7 @@ export default function EditForm({
 
     reloadExpenses?.();
 
-    setIsSheetOpen(false);
+    setIsDialogOpen(false);
   }
 
   const handleTypeChange = (selectedTypeId: string) => {
@@ -106,15 +107,17 @@ export default function EditForm({
   };
 
   return (
-    <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
-      <SheetTrigger asChild>
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DialogTrigger asChild>
         <EditButton />
-      </SheetTrigger>
-      <SheetContent className="w-[500px] max-h-screen overflow-y-auto p-4">
-        <SheetHeader>
-          <SheetTitle>Editar Despesa</SheetTitle>
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+      </DialogTrigger>
+      <DialogContent className="max-w-[1200px] max-h-screen overflow-y-auto p-4">
+        <DialogHeader>
+          <DialogTitle>Editar Despesa</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <div className="grid grid-cols-2 gap-4">
               <FormField
                 control={form.control}
                 name="expense"
@@ -283,18 +286,16 @@ export default function EditForm({
                   </FormItem>
                 )}
               />
-              <Button
-                type="submit"
-                className="bg-blue-600 rounded-full p-2 mr-2"
-              >
-                <p className="flex text-white font-medium">
-                  <Pencil color="#ffffff" height={15} /> Editar
-                </p>
-              </Button>
-            </form>
-          </Form>
-        </SheetHeader>
-      </SheetContent>
-    </Sheet>
+            </div>
+            <DialogFooter className="flex justify-end items-center">
+              <DialogClose asChild>
+                <Button variant={"outline"}>Cancelar</Button>
+              </DialogClose>
+              <Button type="submit">Editar</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/features/income/components/IncomeCreateForm.tsx
+++ b/src/features/income/components/IncomeCreateForm.tsx
@@ -24,11 +24,11 @@ import {
   DialogClose,
   DialogContent,
   DialogDescription,
+  DialogFooter,
+  DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import { DialogFooter, DialogHeader } from '@/components/ui/dialog';
-import { Plus } from 'lucide-react';
 
 const formSchema = z.object({
   income: z.string().min(2, {
@@ -66,79 +66,75 @@ export default function CreateForm() {
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
           <DialogTrigger asChild>
-            <Button className="w-32">
-              <Plus />
-              Entrada
-            </Button>
+            <Button className="w-32">Entrada</Button>
           </DialogTrigger>
-          <DialogContent className="sm:max-w-[425px]">
+          <DialogContent className="max-w-[1200px] max-h-screen overflow-y-auto p-4">
             <DialogHeader>
               <DialogTitle>Cadastrar uma entrada</DialogTitle>
               <DialogDescription>Cadastre uma nova entrada.</DialogDescription>
             </DialogHeader>
-
-            <FormField
-              control={form.control}
-              name="income"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Entrada</FormLabel>
-                  <FormControl>
-                    <Input required {...field} />
-                  </FormControl>
-                  <FormDescription>
-                    Este é o nome da sua entrada.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="description"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Descrição</FormLabel>
-                  <FormControl>
-                    <Input required {...field} />
-                  </FormControl>
-                  <FormDescription>
-                    Este é a descrição da sua entrada.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <MoneyInput
-              form={form}
-              label="Valor"
-              name="amount"
-              placeholder=""
-              description="Este é o valor da sua entrada."
-            />
-            <FormField
-              control={form.control}
-              name="date"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Date</FormLabel>
-                  <FormControl>
-                    <Input required type="date" {...field} />
-                  </FormControl>
-                  <FormDescription>
-                    Esta é a data da sua entrada.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <DialogFooter>
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="income"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Entrada</FormLabel>
+                    <FormControl>
+                      <Input required {...field} />
+                    </FormControl>
+                    <FormDescription>
+                      Este é o nome da sua entrada.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Descrição</FormLabel>
+                    <FormControl>
+                      <Input required {...field} />
+                    </FormControl>
+                    <FormDescription>
+                      Este é a descrição da sua entrada.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <MoneyInput
+                form={form}
+                label="Valor"
+                name="amount"
+                placeholder=""
+                description="Este é o valor da sua entrada."
+              />
+              <FormField
+                control={form.control}
+                name="date"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Date</FormLabel>
+                    <FormControl>
+                      <Input required type="date" {...field} />
+                    </FormControl>
+                    <FormDescription>
+                      Esta é a data da sua entrada.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <DialogFooter className="flex justify-end items-center">
               <DialogClose asChild>
-                <Button variant="outline">Cancel</Button>
+                <Button variant="outline">Cancelar</Button>
               </DialogClose>
-              <Button type="submit" onClick={onSubmit}>
-                Salvar
-              </Button>
+              <Button type="submit">Salvar</Button>
             </DialogFooter>
           </DialogContent>
         </form>

--- a/src/features/income/components/IncomeEditForm.tsx
+++ b/src/features/income/components/IncomeEditForm.tsx
@@ -2,12 +2,14 @@
 
 import React, { useState } from 'react';
 import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from '@/components/ui/sheet';
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogClose,
+} from '@/components/ui/dialog';
 import {
   Form,
   FormControl,
@@ -23,7 +25,6 @@ import { FieldValues, useForm } from 'react-hook-form';
 import { Income } from '../types/income';
 import { editIncome } from '../api/edit-income';
 import { useToast } from '@/hooks/use-toast';
-import { Pencil } from 'lucide-react';
 import MoneyInput from '@/components/common/money-input';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -49,7 +50,7 @@ export default function EditForm({
   incomeId: string;
   reloadIncomes?: () => void;
 }) {
-  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
   const { toast } = useToast();
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -74,19 +75,21 @@ export default function EditForm({
 
     reloadIncomes?.();
 
-    setIsSheetOpen(false);
+    setIsDialogOpen(false);
   }
 
   return (
-    <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
-      <SheetTrigger asChild>
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DialogTrigger asChild>
         <EditButton />
-      </SheetTrigger>
-      <SheetContent className="w-[500px] max-h-screen overflow-y-auto p-4">
-        <SheetHeader>
-          <SheetTitle>Editar Entrada</SheetTitle>
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+      </DialogTrigger>
+      <DialogContent className="max-w-[1200px] max-h-screen overflow-y-auto p-4">
+        <DialogHeader>
+          <DialogTitle>Editar Entrada</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <div className="grid grid-cols-2 gap-4">
               <FormField
                 control={form.control}
                 name="income"
@@ -142,18 +145,16 @@ export default function EditForm({
                   </FormItem>
                 )}
               />
-              <Button
-                type="submit"
-                className="bg-blue-600 rounded-full p-2 mr-2"
-              >
-                <p className="flex text-white font-medium">
-                  <Pencil color="#ffffff" height={15} /> Editar
-                </p>
-              </Button>
-            </form>
-          </Form>
-        </SheetHeader>
-      </SheetContent>
-    </Sheet>
+            </div>
+            <DialogFooter className="flex justify-end items-center">
+              <DialogClose asChild>
+                <Button variant={"outline"}>Cancelar</Button>
+              </DialogClose>
+              <Button type="submit">Editar</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/features/objective/components/ObjectiveCreateForm.tsx
+++ b/src/features/objective/components/ObjectiveCreateForm.tsx
@@ -2,12 +2,14 @@
 
 import React, { useState } from 'react';
 import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from '@/components/ui/sheet';
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogClose,
+} from '@/components/ui/dialog';
 import {
   Form,
   FormControl,
@@ -47,7 +49,7 @@ export default function CreateForm({
 }: {
   onObjectiveCreated: () => void;
 }) {
-  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -68,23 +70,25 @@ export default function CreateForm({
 
     onObjectiveCreated();
 
-    setIsSheetOpen(false);
+    setIsDialogOpen(false);
   }
 
   return (
-    <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
-      <SheetTrigger asChild>
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DialogTrigger asChild>
         <CreateButton />
-      </SheetTrigger>
-      <SheetContent className="w-[500px] max-h-screen overflow-y-auto p-4">
-        <SheetHeader>
-          <SheetTitle>Cadastro de Objetivo</SheetTitle>
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+      </DialogTrigger>
+      <DialogContent className="max-w-[1200px] max-h-screen overflow-y-auto p-4">
+        <DialogHeader>
+          <DialogTitle>Cadastro de Objetivo</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <div className="grid grid-cols-2 gap-4">
               <FormField
                 control={form.control}
                 name="objective"
-              render={() => (
+                render={({ field }) => (
                   <FormItem>
                     <FormLabel>Objetivo</FormLabel>
                     <FormControl>
@@ -100,7 +104,7 @@ export default function CreateForm({
               <FormField
                 control={form.control}
                 name="description"
-              render={() => (
+                render={({ field }) => (
                   <FormItem>
                     <FormLabel>Descrição</FormLabel>
                     <FormControl>
@@ -149,11 +153,16 @@ export default function CreateForm({
                   </FormItem>
                 )}
               />
+            </div>
+            <DialogFooter className="flex justify-end items-center">
+              <DialogClose asChild>
+                <Button variant="outline">Cancelar</Button>
+              </DialogClose>
               <Button type="submit">Criar</Button>
-            </form>
-          </Form>
-        </SheetHeader>
-      </SheetContent>
-    </Sheet>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/features/objective/components/ObjectiveEditForm.tsx
+++ b/src/features/objective/components/ObjectiveEditForm.tsx
@@ -2,12 +2,14 @@
 
 import React, { useState } from 'react';
 import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from '@/components/ui/sheet';
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogClose,
+} from '@/components/ui/dialog';
 import {
   Form,
   FormControl,
@@ -23,7 +25,6 @@ import { FieldValues, useForm } from 'react-hook-form';
 import { editObjective } from '../api/edit-objective';
 import { Objective } from '../types/objective';
 import { useToast } from '@/hooks/use-toast';
-import { Pencil } from 'lucide-react';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import EditButton from '@/components/common/edit-button';
@@ -52,7 +53,7 @@ export default function EditForm({
   objectiveId: string;
   reloadObjectives?: () => void;
 }) {
-  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
   const { toast } = useToast();
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -77,19 +78,21 @@ export default function EditForm({
 
     reloadObjectives?.();
 
-    setIsSheetOpen(false);
+    setIsDialogOpen(false);
   }
 
   return (
-    <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
-      <SheetTrigger asChild>
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DialogTrigger asChild>
         <EditButton />
-      </SheetTrigger>
-      <SheetContent className="w-[500px] max-h-screen overflow-y-auto p-4">
-        <SheetHeader>
-          <SheetTitle>Editar Objetivo</SheetTitle>
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+      </DialogTrigger>
+      <DialogContent className="max-w-[1200px] max-h-screen overflow-y-auto p-4">
+        <DialogHeader>
+          <DialogTitle>Editar Objetivo</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <div className="grid grid-cols-2 gap-4">
               <FormField
                 control={form.control}
                 name="objective"
@@ -158,18 +161,16 @@ export default function EditForm({
                   </FormItem>
                 )}
               />
-              <Button
-                type="submit"
-                className="bg-blue-600 rounded-full p-2 mr-2"
-              >
-                <p className="flex text-white font-medium">
-                  <Pencil color="#ffffff" height={15} /> Editar
-                </p>
-              </Button>
-            </form>
-          </Form>
-        </SheetHeader>
-      </SheetContent>
-    </Sheet>
+            </div>
+            <DialogFooter className="flex justify-end items-center">
+              <DialogClose asChild>
+                <Button variant="outline">Cancelar</Button>
+              </DialogClose>
+              <Button type="submit">Editar</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/features/type/components/TypeCreateForm.tsx
+++ b/src/features/type/components/TypeCreateForm.tsx
@@ -2,12 +2,14 @@
 
 import React, { useState } from 'react';
 import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from '@/components/ui/sheet';
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogClose,
+} from '@/components/ui/dialog';
 import {
   Form,
   FormControl,
@@ -25,7 +27,6 @@ import { Type } from '../types/type';
 import { toast } from 'sonner';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { CirclePlus } from 'lucide-react';
 import { Switch } from '@/components/ui/switch';
 import CreateButton from '@/components/common/create-button';
 
@@ -45,7 +46,7 @@ export default function CreateForm({
 }: {
   onTypeCreated: () => void;
 }) {
-  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -66,19 +67,21 @@ export default function CreateForm({
 
     onTypeCreated();
 
-    setIsSheetOpen(false);
+    setIsDialogOpen(false);
   }
 
   return (
-    <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
-      <SheetTrigger asChild>
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DialogTrigger asChild>
         <CreateButton />
-      </SheetTrigger>
-      <SheetContent className="w-[500px] max-h-screen overflow-y-auto p-4">
-        <SheetHeader>
-          <SheetTitle>Cadastro de Tipo</SheetTitle>
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+      </DialogTrigger>
+      <DialogContent className="max-w-[1200px] max-h-screen overflow-y-auto p-4">
+        <DialogHeader>
+          <DialogTitle>Cadastro de Tipo</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <div className="grid grid-cols-2 gap-4">
               <FormField
                 control={form.control}
                 name="type"
@@ -155,18 +158,16 @@ export default function CreateForm({
                   </FormItem>
                 )}
               />
-              <Button
-                type="submit"
-                className="bg-green-600 rounded-full p-2 mr-2"
-              >
-                <p className="flex text-white font-medium">
-                  <CirclePlus color="#ffffff" height={20} /> Cadastrar
-                </p>
-              </Button>
-            </form>
-          </Form>
-        </SheetHeader>
-      </SheetContent>
-    </Sheet>
+            </div>
+            <DialogFooter className="flex justify-end items-center">
+              <DialogClose asChild>
+                <Button variant={"outline"}>Cancelar</Button>
+              </DialogClose>
+              <Button type="submit">Cadastrar</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/features/type/components/TypeEditForm.tsx
+++ b/src/features/type/components/TypeEditForm.tsx
@@ -2,12 +2,14 @@
 
 import React, { useState } from 'react';
 import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from '@/components/ui/sheet';
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogClose,
+} from '@/components/ui/dialog';
 import {
   Form,
   FormControl,
@@ -25,7 +27,6 @@ import { editType } from '../api/edit-type';
 import { useToast } from '@/hooks/use-toast';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Pencil } from 'lucide-react';
 import { Switch } from '@/components/ui/switch';
 import EditButton from '@/components/common/edit-button';
 
@@ -49,7 +50,7 @@ export default function EditForm({
   typeId: string;
   reloadTypes?: () => void;
 }) {
-  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
   const { toast } = useToast();
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -74,19 +75,21 @@ export default function EditForm({
 
     reloadTypes?.();
 
-    setIsSheetOpen(false);
+    setIsDialogOpen(false);
   }
 
   return (
-    <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
-      <SheetTrigger asChild>
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DialogTrigger asChild>
         <EditButton />
-      </SheetTrigger>
-      <SheetContent className="w-[500px] max-h-screen overflow-y-auto p-4">
-        <SheetHeader>
-          <SheetTitle>Editar Tipo</SheetTitle>
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+      </DialogTrigger>
+      <DialogContent className="max-w-[1200px] max-h-screen overflow-y-auto p-4">
+        <DialogHeader>
+          <DialogTitle>Editar Tipo</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <div className="grid grid-cols-2 gap-4">
               <FormField
                 control={form.control}
                 name="type"
@@ -163,18 +166,16 @@ export default function EditForm({
                   </FormItem>
                 )}
               />
-              <Button
-                type="submit"
-                className="bg-blue-600 rounded-full p-2 mr-2"
-              >
-                <p className="flex text-white font-medium">
-                  <Pencil color="#ffffff" height={15} /> Editar
-                </p>
-              </Button>
-            </form>
-          </Form>
-        </SheetHeader>
-      </SheetContent>
-    </Sheet>
+            </div>
+            <DialogFooter className="flex justify-end items-center">
+              <DialogClose asChild>
+                <Button variant={"outline"}>Cancelar</Button>
+              </DialogClose>
+              <Button type="submit">Editar</Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
   );
 }


### PR DESCRIPTION
## Summary
- convert all form dialogs to use a uniform layout
- add a grid container for two-column inputs
- standardize dialog footers with cancel and submit buttons
- set dialog width to `max-w-[1200px]`
- remove unused icon imports

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module 'react-day-picker')*


------
https://chatgpt.com/codex/tasks/task_e_6864790e04b4832090758da25c7b3140