### PR TITLE
Fix expense table pagination

### DIFF
--- a/src/features/expense/components/ExpenseDataTable.tsx
+++ b/src/features/expense/components/ExpenseDataTable.tsx
@@ -54,7 +54,16 @@ export function DataTable<TData, TValue>({
       sorting,
       columnFilters,
     },
+    initialState: {
+      pagination: {
+        pageSize: data.length,
+      },
+    },
   });
+
+  React.useEffect(() => {
+    table.setPageSize(data.length);
+  }, [data.length, table]);
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- show all expenses on a single page by setting the page size to the amount of data

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865a5c9eef883209020c08a3fc3815f