### PR TITLE
Fix pagination across pages

### DIFF
--- a/src/features/card/api/get-cards.ts
+++ b/src/features/card/api/get-cards.ts
@@ -1,9 +1,9 @@
 import { httpGet } from '@/services/api/http';
 import { CardResponse } from '../types/card';
 
-export async function getCards(): Promise<CardResponse> {
+export async function getCards(page = 1): Promise<CardResponse> {
   try {
-    const API_URL = '/cards';
+    const API_URL = `/cards?page=${page}`;
 
     const response = await httpGet<CardResponse>(API_URL);
 

--- a/src/features/card/pages/CardPage.tsx
+++ b/src/features/card/pages/CardPage.tsx
@@ -11,29 +11,33 @@ import Loader from '@/components/common/loading';
 const CardPage = () => {
   const [cards, setCards] = useState<CardType[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  useEffect(() => {
-    const fetchUsers = async () => {
-      try {
-        setIsLoading(true);
-        const data = await getCards();
-        setCards(data);
-      } catch (error) {
-        console.error('Erro ao carregar os dados:', error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
+  const PAGE_SIZE = 15;
 
-    fetchUsers();
+  const fetchAllCards = async () => {
+    try {
+      setIsLoading(true);
+      const allCards: CardType[] = [];
+      let page = 1;
+      let data: CardType[] = [];
+      do {
+        data = await getCards(page);
+        allCards.push(...data);
+        page += 1;
+      } while (data.length === PAGE_SIZE);
+      setCards(allCards);
+    } catch (error) {
+      console.error('Erro ao carregar os dados:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAllCards();
   }, []);
 
   const reloadCards = async () => {
-    try {
-      const data = await getCards();
-      setCards(data);
-    } catch (error) {
-      console.error('Error reloading cards:', error);
-    }
+    await fetchAllCards();
   };
 
   return (

--- a/src/features/category/api/get-categories.ts
+++ b/src/features/category/api/get-categories.ts
@@ -1,9 +1,9 @@
 import { httpGet } from '@/services/api/http';
 import { CategoryResponse } from '../types/category';
 
-export async function getCategories(): Promise<CategoryResponse> {
+export async function getCategories(page = 1): Promise<CategoryResponse> {
   try {
-    const API_URL = '/categories';
+    const API_URL = `/categories?page=${page}`;
 
     const response = await httpGet<CategoryResponse>(API_URL);
 

--- a/src/features/category/pages/CategoryPage.tsx
+++ b/src/features/category/pages/CategoryPage.tsx
@@ -11,29 +11,33 @@ import Loader from '@/components/common/loading';
 const CategoryPage = () => {
   const [categories, setCategories] = useState<Category[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  useEffect(() => {
-    const fetchUsers = async () => {
-      try {
-        setIsLoading(true);
-        const data = await getCategories();
-        setCategories(data);
-      } catch (error) {
-        console.error('Erro ao carregar os dados:', error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
+  const PAGE_SIZE = 15;
 
-    fetchUsers();
+  const fetchAllCategories = async () => {
+    try {
+      setIsLoading(true);
+      const allCategories: Category[] = [];
+      let page = 1;
+      let data: Category[] = [];
+      do {
+        data = await getCategories(page);
+        allCategories.push(...data);
+        page += 1;
+      } while (data.length === PAGE_SIZE);
+      setCategories(allCategories);
+    } catch (error) {
+      console.error('Erro ao carregar os dados:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAllCategories();
   }, []);
 
   const reloadCategories = async () => {
-    try {
-      const data = await getCategories();
-      setCategories(data);
-    } catch (error) {
-      console.error('Error reloading categories:', error);
-    }
+    await fetchAllCategories();
   };
 
   return (

--- a/src/features/expense/api/get-expenses.ts
+++ b/src/features/expense/api/get-expenses.ts
@@ -1,8 +1,8 @@
 import { httpGet } from '@/services/api/http';
 import { ExpenseResponse } from '../types/expense';
 
-export async function getExpenses(): Promise<ExpenseResponse> {
-  const API_URL = '/expenses';
+export async function getExpenses(page = 1): Promise<ExpenseResponse> {
+  const API_URL = `/expenses?page=${page}`;
 
   const response = await httpGet<ExpenseResponse>(API_URL);
 

--- a/src/features/expense/pages/ExpensePage.tsx
+++ b/src/features/expense/pages/ExpensePage.tsx
@@ -11,29 +11,33 @@ import Loader from '@/components/common/loading';
 const ExpensePage = () => {
   const [expenses, setExpenses] = useState<Expense[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  useEffect(() => {
-    const fetchUsers = async () => {
-      try {
-        setIsLoading(true);
-        const data = await getExpenses();
-        setExpenses(data);
-      } catch (error) {
-        console.error('Erro ao carregar os dados:', error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
+  const PAGE_SIZE = 15;
 
-    fetchUsers();
+  const fetchAllExpenses = async () => {
+    try {
+      setIsLoading(true);
+      const allExpenses: Expense[] = [];
+      let page = 1;
+      let data: Expense[] = [];
+      do {
+        data = await getExpenses(page);
+        allExpenses.push(...data);
+        page += 1;
+      } while (data.length === PAGE_SIZE);
+      setExpenses(allExpenses);
+    } catch (error) {
+      console.error('Erro ao carregar os dados:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAllExpenses();
   }, []);
 
   const reloadExpenses = async () => {
-    try {
-      const data = await getExpenses();
-      setExpenses(data);
-    } catch (error) {
-      console.error('Error reloading expenses:', error);
-    }
+    await fetchAllExpenses();
   };
 
   return (

--- a/src/features/income/api/get-incomes.ts
+++ b/src/features/income/api/get-incomes.ts
@@ -1,8 +1,8 @@
 import { httpGet } from '@/services/api/http';
 import { IncomeResponse } from '../types/income';
 
-export async function getIncomes(): Promise<IncomeResponse> {
-  const API_URL = '/incomes';
+export async function getIncomes(page = 1): Promise<IncomeResponse> {
+  const API_URL = `/incomes?page=${page}`;
 
   const response = await httpGet<IncomeResponse>(API_URL);
 

--- a/src/features/income/components/IncomePage.tsx
+++ b/src/features/income/components/IncomePage.tsx
@@ -11,29 +11,33 @@ import Loader from '@/components/common/loading';
 const IncomePage = () => {
   const [encomes, setIncomes] = useState<Income[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  useEffect(() => {
-    const fetchUsers = async () => {
-      try {
-        setIsLoading(true);
-        const data = await getIncomes();
-        setIncomes(data);
-      } catch (error) {
-        console.error('Erro ao carregar os dados:', error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
+  const PAGE_SIZE = 15;
 
-    fetchUsers();
+  const fetchAllIncomes = async () => {
+    try {
+      setIsLoading(true);
+      const allIncomes: Income[] = [];
+      let page = 1;
+      let data: Income[] = [];
+      do {
+        data = await getIncomes(page);
+        allIncomes.push(...data);
+        page += 1;
+      } while (data.length === PAGE_SIZE);
+      setIncomes(allIncomes);
+    } catch (error) {
+      console.error('Erro ao carregar os dados:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAllIncomes();
   }, []);
 
   const reloadIncomes = async () => {
-    try {
-      const data = await getIncomes();
-      setIncomes(data);
-    } catch (error) {
-      console.error('Error reloading encomes:', error);
-    }
+    await fetchAllIncomes();
   };
 
   return (

--- a/src/features/objective/api/get-objectives.ts
+++ b/src/features/objective/api/get-objectives.ts
@@ -1,8 +1,8 @@
 import { httpGet } from '@/services/api/http';
 import { ObjectiveResponse } from '../types/objective';
 
-export async function getObjectives(): Promise<ObjectiveResponse> {
-  const API_URL = '/objectives';
+export async function getObjectives(page = 1): Promise<ObjectiveResponse> {
+  const API_URL = `/objectives?page=${page}`;
 
   const response = await httpGet<ObjectiveResponse>(API_URL);
 

--- a/src/features/objective/pages/ObjectivePage.tsx
+++ b/src/features/objective/pages/ObjectivePage.tsx
@@ -11,30 +11,33 @@ import Loader from '@/components/common/loading';
 const ObjectivePage = () => {
   const [objectives, setObjectives] = useState<Objective[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const PAGE_SIZE = 15;
+
+  const fetchAllObjectives = async () => {
+    try {
+      setIsLoading(true);
+      const allObjectives: Objective[] = [];
+      let page = 1;
+      let data: Objective[] = [];
+      do {
+        data = await getObjectives(page);
+        allObjectives.push(...data);
+        page += 1;
+      } while (data.length === PAGE_SIZE);
+      setObjectives(allObjectives);
+    } catch (error) {
+      console.error('Erro ao carregar os dados:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
   useEffect(() => {
-    const fetchObjectives = async () => {
-      try {
-        setIsLoading(true);
-        const data = await getObjectives();
-        setObjectives(data);
-      } catch (error) {
-        console.error('Erro ao carregar os dados:', error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchObjectives();
+    fetchAllObjectives();
   }, []);
 
   const reloadObjectives = async () => {
-    try {
-      const data = await getObjectives();
-      setObjectives(data);
-    } catch (error) {
-      console.error('Error reloading objectives:', error);
-    }
+    await fetchAllObjectives();
   };
 
   return (

--- a/src/features/type/api/get-types.ts
+++ b/src/features/type/api/get-types.ts
@@ -1,9 +1,9 @@
 import { httpGet } from '@/services/api/http';
 import { TypeResponse } from '../types/type';
 
-export async function getTypes(): Promise<TypeResponse> {
+export async function getTypes(page = 1): Promise<TypeResponse> {
   try {
-    const API_URL = '/types';
+    const API_URL = `/types?page=${page}`;
 
     const response = await httpGet<TypeResponse>(API_URL);
 

--- a/src/features/type/pages/TypePage.tsx
+++ b/src/features/type/pages/TypePage.tsx
@@ -11,29 +11,33 @@ import Loader from '@/components/common/loading';
 const TypePage = () => {
   const [types, setTypes] = useState<Type[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  useEffect(() => {
-    const fetchUsers = async () => {
-      try {
-        setIsLoading(true);
-        const data = await getTypes();
-        setTypes(data);
-      } catch (error) {
-        console.error('Erro ao carregar os dados:', error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
+  const PAGE_SIZE = 15;
 
-    fetchUsers();
+  const fetchAllTypes = async () => {
+    try {
+      setIsLoading(true);
+      const allTypes: Type[] = [];
+      let page = 1;
+      let data: Type[] = [];
+      do {
+        data = await getTypes(page);
+        allTypes.push(...data);
+        page += 1;
+      } while (data.length === PAGE_SIZE);
+      setTypes(allTypes);
+    } catch (error) {
+      console.error('Erro ao carregar os dados:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAllTypes();
   }, []);
 
   const reloadTypes = async () => {
-    try {
-      const data = await getTypes();
-      setTypes(data);
-    } catch (error) {
-      console.error('Error reloading types:', error);
-    }
+    await fetchAllTypes();
   };
 
   return (


### PR DESCRIPTION
## Summary
- load all pages for cards, categories, incomes, objectives and types
- fetch individual pages via `getCards`, `getCategories`, `getIncomes`, `getObjectives`, `getTypes`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865a5c9eef883209020c08a3fc3815f