### PR TITLE
Fix installments input default state

### DIFF
--- a/src/features/expense/components/ExpenseCreateForm.tsx
+++ b/src/features/expense/components/ExpenseCreateForm.tsx
@@ -88,6 +88,7 @@ export default function CreateForm({
     if (defaultType) {
       setDefaultTypeId(defaultType.id);
       form.setValue('type_id', defaultType.id);
+      setInstallmentsEnabled(defaultType.installments === true);
     }
 
     if (defaultCard) {

--- a/src/features/expense/components/ExpenseEditForm.tsx
+++ b/src/features/expense/components/ExpenseEditForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -83,6 +83,11 @@ export default function EditForm({
       installments: expense.installments,
     },
   });
+
+  useEffect(() => {
+    const currentType = types.find((type) => type.id === expense.type_id);
+    setInstallmentsEnabled(currentType?.installments === true);
+  }, [types, expense.type_id]);
 
   function onSubmit(data: FieldValues) {
     const expenseData = data as Expense;


### PR DESCRIPTION
## Summary
- enable installments field when default type has installments
- enable installments field when editing an expense with installment type

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68671197d53c8320818b25dcfc1bd7c9