### PR TITLE
Add date range filters for home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,16 @@
 import HomePage from '@/features/home/components/HomePage';
 import { TypesProvider } from '@/context/TypesContext';
 import { MonthSummaryProvider } from '@/context/MonthSummaryContext';
+import { HomeDateRangeProvider } from '@/context/HomeDateRangeContext';
 
 export default function Page() {
   return (
-    <MonthSummaryProvider>
-      <TypesProvider>
-        <HomePage />
-      </TypesProvider>
-    </MonthSummaryProvider>
+    <HomeDateRangeProvider>
+      <MonthSummaryProvider>
+        <TypesProvider>
+          <HomePage />
+        </TypesProvider>
+      </MonthSummaryProvider>
+    </HomeDateRangeProvider>
   );
 }

--- a/src/components/common/calendar-range.tsx
+++ b/src/components/common/calendar-range.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import React from 'react';
 import { ChevronDownIcon } from 'lucide-react';
 import { type DateRange } from 'react-day-picker';
 
@@ -12,9 +12,12 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 
-export default function CalendarRange() {
-  const [range, setRange] = React.useState<DateRange | undefined>(undefined);
+interface CalendarRangeProps {
+  range: DateRange | undefined;
+  onChange: (range: DateRange | undefined) => void;
+}
 
+export default function CalendarRange({ range, onChange }: CalendarRangeProps) {
   return (
     <div className="flex flex-col gap-3">
       <Popover>
@@ -35,8 +38,8 @@ export default function CalendarRange() {
             mode="range"
             selected={range}
             captionLayout="dropdown"
-            onSelect={(range) => {
-              setRange(range);
+            onSelect={(newRange) => {
+              onChange(newRange);
             }}
           />
         </PopoverContent>

--- a/src/context/HomeDateRangeContext.tsx
+++ b/src/context/HomeDateRangeContext.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import React, { createContext, useContext, useState } from 'react';
+import { type DateRange } from 'react-day-picker';
+
+interface HomeDateRangeContextValue {
+  expenseRange: DateRange | undefined;
+  incomeRange: DateRange | undefined;
+  setExpenseRange: React.Dispatch<React.SetStateAction<DateRange | undefined>>;
+  setIncomeRange: React.Dispatch<React.SetStateAction<DateRange | undefined>>;
+}
+
+const HomeDateRangeContext = createContext<HomeDateRangeContextValue | null>(
+  null,
+);
+
+export const HomeDateRangeProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const today = new Date();
+  const firstDay = new Date(today.getFullYear(), today.getMonth(), 1);
+  const defaultRange: DateRange = { from: firstDay, to: today };
+  const [expenseRange, setExpenseRange] = useState<DateRange | undefined>(defaultRange);
+  const [incomeRange, setIncomeRange] = useState<DateRange | undefined>(defaultRange);
+
+  return (
+    <HomeDateRangeContext.Provider
+      value={{ expenseRange, incomeRange, setExpenseRange, setIncomeRange }}
+    >
+      {children}
+    </HomeDateRangeContext.Provider>
+  );
+};
+
+export const useHomeDateRange = () => {
+  const context = useContext(HomeDateRangeContext);
+  if (!context) {
+    throw new Error(
+      'useHomeDateRange must be used within a HomeDateRangeProvider',
+    );
+  }
+  return context;
+};

--- a/src/context/MonthSummaryContext.tsx
+++ b/src/context/MonthSummaryContext.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { MonthSummary } from '@/types/month-summary';
 import { getMonthSummary } from '@/features/home/api/get-month-summary';
+import { useHomeDateRange } from './HomeDateRangeContext';
 
 interface MonthSummaryContextValue {
   monthSummary: MonthSummary | undefined;
@@ -18,12 +19,24 @@ export const MonthSummaryProvider = ({
   children: React.ReactNode;
 }) => {
   const [monthSummary, setMonthSummary] = useState<MonthSummary>();
-  const month = new Date().getMonth() + 1;
-  const year = new Date().getFullYear();
+  const { expenseRange, incomeRange } = useHomeDateRange();
   useEffect(() => {
     const fetchMonthSummary = async () => {
       try {
-        const data = await getMonthSummary(year, month);
+        if (
+          !expenseRange?.from ||
+          !expenseRange?.to ||
+          !incomeRange?.from ||
+          !incomeRange?.to
+        ) {
+          return;
+        }
+        const data = await getMonthSummary(
+          expenseRange.from.toISOString().slice(0, 10),
+          expenseRange.to.toISOString().slice(0, 10),
+          incomeRange.from.toISOString().slice(0, 10),
+          incomeRange.to.toISOString().slice(0, 10),
+        );
         setMonthSummary(data);
       } catch (error) {
         console.error('Error fetching types:', error);
@@ -31,7 +44,7 @@ export const MonthSummaryProvider = ({
     };
 
     fetchMonthSummary();
-  }, [year, month]);
+  }, [expenseRange, incomeRange]);
 
   return (
     <MonthSummaryContext.Provider value={{ monthSummary }}>

--- a/src/features/home/api/get-month-summary.ts
+++ b/src/features/home/api/get-month-summary.ts
@@ -2,11 +2,13 @@ import { httpGet } from '@/services/api/http';
 import { MonthSummary } from '@/types/month-summary';
 
 export async function getMonthSummary(
-  year: number,
-  month: number,
+  expenseStart: string,
+  expenseEnd: string,
+  incomeStart: string,
+  incomeEnd: string,
 ): Promise<MonthSummary> {
   try {
-    const API_URL = `monthly-summary/${year}/${month}`;
+    const API_URL = `monthly-summary?expense_start=${expenseStart}&expense_end=${expenseEnd}&income_start=${incomeStart}&income_end=${incomeEnd}`;
 
     const response = await httpGet<MonthSummary>(API_URL);
     return response;

--- a/src/features/home/api/list-expenses-by-type.ts
+++ b/src/features/home/api/list-expenses-by-type.ts
@@ -2,15 +2,14 @@ import { httpGet } from '@/services/api/http';
 import { ExpensesByTypeResponse } from '../types/home';
 
 export async function listExpensesByType(
-  month: number,
-  year: number,
+  start: string,
+  end: string,
   typeId: string,
 ): Promise<ExpensesByTypeResponse> {
   try {
-    const API_URL = `types/${typeId}/expenses/${year}/${month}`;
+    const API_URL = `types/${typeId}/expenses?start=${start}&end=${end}`;
 
     const response = await httpGet<ExpensesByTypeResponse>(API_URL);
-    console.log(response);
     return response;
   } catch {
     throw new Error('Falha ao buscar as despesas do tipo');

--- a/src/features/home/api/list-expenses-per-type.ts
+++ b/src/features/home/api/list-expenses-per-type.ts
@@ -2,12 +2,12 @@ import { httpGet } from '@/services/api/http';
 import { Expense } from '@/features/expense/types/expense';
 
 export async function listExpensesPerType(
-  month: number,
-  year: number,
+  start: string,
+  end: string,
   type_id: string,
 ): Promise<Expense[]> {
   try {
-    const API_URL = `expenses/by-type/${type_id}/${year}/${month}`;
+    const API_URL = `expenses/by-type/${type_id}?start=${start}&end=${end}`;
 
     const response = await httpGet<Expense[]>(API_URL);
 

--- a/src/features/home/api/list-expenses-with-installments.ts
+++ b/src/features/home/api/list-expenses-with-installments.ts
@@ -2,16 +2,16 @@ import { httpGet } from '@/services/api/http';
 import { Expense } from '@/features/expense/types/expense';
 
 export async function listExpensesWithInstallments(
-  year: number,
-  month: number,
+  start: string,
+  end: string,
 ): Promise<Expense[]> {
   try {
-    const API_URL = `expenses/with-installments/${year}/${month}`;
+    const API_URL = `expenses/with-installments?start=${start}&end=${end}`;
 
     const response = await httpGet<Expense[]>(API_URL);
 
     return response;
   } catch {
-    throw new Error('Falha ao buscar as categorias' + month);
+    throw new Error('Falha ao buscar as categorias');
   }
 }

--- a/src/features/home/api/list-recent-transactions.ts
+++ b/src/features/home/api/list-recent-transactions.ts
@@ -1,9 +1,12 @@
 import { httpGet } from '@/services/api/http';
 import { RecentTransactionResponse } from '../types/home';
 
-export async function listRecentTransactions(): Promise<RecentTransactionResponse> {
+export async function listRecentTransactions(
+  start: string,
+  end: string,
+): Promise<RecentTransactionResponse> {
   try {
-    const API_URL = 'recent-transactions';
+    const API_URL = `recent-transactions?start=${start}&end=${end}`;
 
     const response = await httpGet<RecentTransactionResponse>(API_URL);
 

--- a/src/features/home/api/list-top-categories.ts
+++ b/src/features/home/api/list-top-categories.ts
@@ -2,11 +2,11 @@ import { httpGet } from '@/services/api/http';
 import { TopCategoryResponse } from '../types/home';
 
 export async function listTopCategories(
-  month: number,
-  year: number,
+  start: string,
+  end: string,
 ): Promise<TopCategoryResponse> {
   try {
-    const API_URL = `categories/top-expenses/${month}/${year}`;
+    const API_URL = `categories/top-expenses?start=${start}&end=${end}`;
 
     const response = await httpGet<TopCategoryResponse>(API_URL);
 

--- a/src/features/home/components/CategoriesCard.tsx
+++ b/src/features/home/components/CategoriesCard.tsx
@@ -10,16 +10,20 @@ import {
 import { Progress } from '@/components/ui/progress';
 import { HandCoins } from 'lucide-react';
 import { listTopCategories } from '../api/list-top-categories';
+import { useHomeDateRange } from '@/context/HomeDateRangeContext';
 import { TopCategory } from '../types/home';
 
 export default function BalanceCard() {
   const [categories, setCategories] = useState<TopCategory[]>([]);
-  const month = new Date().getMonth() + 1;
-  const year = new Date().getFullYear();
+  const { expenseRange } = useHomeDateRange();
+
   const fetchCategories = useCallback(async () => {
-    const data = await listTopCategories(month, year);
+    if (!expenseRange?.from || !expenseRange?.to) return;
+    const start = expenseRange.from.toISOString().slice(0, 10);
+    const end = expenseRange.to.toISOString().slice(0, 10);
+    const data = await listTopCategories(start, end);
     setCategories(data);
-  }, [month, year]);
+  }, [expenseRange]);
 
   useEffect(() => {
     fetchCategories();

--- a/src/features/home/components/ExpensePerType.tsx
+++ b/src/features/home/components/ExpensePerType.tsx
@@ -19,21 +19,22 @@ import {
 } from '@/components/ui/table';
 import { HandCoins } from 'lucide-react';
 import { listExpensesPerType } from '../api/list-expenses-per-type';
-import { MonthSelect } from '@/components/common/month-select';
-import { YearSelect } from '@/components/common/year-select';
 import { TypeSelect } from '@/components/common/type-select';
 import { Expense } from '@/features/expense/types/expense';
+import { useHomeDateRange } from '@/context/HomeDateRangeContext';
 
 export default function ExpensePerType() {
   const [types, setTypes] = useState<Expense[]>([]);
-  const [month, setMonth] = useState<number>(new Date().getMonth() + 1);
-  const [year, setYear] = useState<number>(new Date().getFullYear());
   const [selectedTypeId, setSelectedTypeId] = useState<string>('');
+  const { expenseRange } = useHomeDateRange();
 
   const fetchTypes = useCallback(async () => {
-    const data = await listExpensesPerType(month, year, selectedTypeId);
+    if (!expenseRange?.from || !expenseRange?.to || !selectedTypeId) return;
+    const start = expenseRange.from.toISOString().slice(0, 10);
+    const end = expenseRange.to.toISOString().slice(0, 10);
+    const data = await listExpensesPerType(start, end, selectedTypeId);
     setTypes(data);
-  }, [month, year, selectedTypeId]);
+  }, [expenseRange, selectedTypeId]);
 
   const handleTypeChange = (value: string) => {
     setSelectedTypeId(value);
@@ -48,8 +49,6 @@ export default function ExpensePerType() {
     <div>
       <div className="flex justify-end gap-2 mb-2">
         <TypeSelect typeId={selectedTypeId} setTypeId={handleTypeChange} />
-        <MonthSelect month={month} setMonth={setMonth} />
-        <YearSelect year={year} setYear={setYear} />
       </div>
       <Card>
         <CardHeader>

--- a/src/features/home/components/HomePage.tsx
+++ b/src/features/home/components/HomePage.tsx
@@ -1,19 +1,25 @@
+'use client';
+
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import TopCards from './TopCards';
 import ObjectiveList from '@/features/objective/components/ObjectiveList';
 import ExpensePerType from './ExpensePerType';
 import CalendarRange from '@/components/common/calendar-range';
+import { useHomeDateRange } from '@/context/HomeDateRangeContext';
 
 export default function HomePage() {
+  const { expenseRange, incomeRange, setExpenseRange, setIncomeRange } =
+    useHomeDateRange();
+
   return (
     <div>
       <div className="justify-between flex items-center mb-2">
         <div className="font-bold text-2xl">Página Inicial</div>
         <div className="grid grid-cols-2 gap-2">
           <div>Período de gastos</div>
-          <CalendarRange />
+          <CalendarRange range={expenseRange} onChange={setExpenseRange} />
           <div>Período de ganhos</div>
-          <CalendarRange />
+          <CalendarRange range={incomeRange} onChange={setIncomeRange} />
         </div>
       </div>
       <Tabs defaultValue="home">

--- a/src/features/home/components/InstallmentsCard.tsx
+++ b/src/features/home/components/InstallmentsCard.tsx
@@ -17,16 +17,19 @@ import {
 } from '@/components/ui/table';
 import { HandCoins } from 'lucide-react';
 import { listExpensesWithInstallments } from '../api/list-expenses-with-installments';
+import { useHomeDateRange } from '@/context/HomeDateRangeContext';
 import { Expense } from '@/features/expense/types/expense';
 
 export default function InstallmentsCard() {
   const [expenses, setExpenses] = useState<Expense[]>([]);
-  const month = new Date().getMonth() + 1;
-  const year = new Date().getFullYear();
+  const { expenseRange } = useHomeDateRange();
   const fetchExpenses = useCallback(async () => {
-    const data = await listExpensesWithInstallments(year, month);
+    if (!expenseRange?.from || !expenseRange?.to) return;
+    const start = expenseRange.from.toISOString().slice(0, 10);
+    const end = expenseRange.to.toISOString().slice(0, 10);
+    const data = await listExpensesWithInstallments(start, end);
     setExpenses(data);
-  }, [month, year]);
+  }, [expenseRange]);
 
   useEffect(() => {
     fetchExpenses();

--- a/src/features/home/components/TransactionsCard.tsx
+++ b/src/features/home/components/TransactionsCard.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/card';
 import { ArrowDownLeft, ArrowUpRight, HandCoins } from 'lucide-react';
 import { listRecentTransactions } from '../api/list-recent-transactions';
+import { useHomeDateRange } from '@/context/HomeDateRangeContext';
 import { RecentTransaction } from '../types/home';
 import { useEffect, useState } from 'react';
 
@@ -16,10 +17,28 @@ export default function TransactionsCard() {
   const [recentTransactions, setRecentTransaction] = useState<
     RecentTransaction[]
   >([]);
+  const { expenseRange, incomeRange } = useHomeDateRange();
   useEffect(() => {
     const fetchTransactions = async () => {
+      if (
+        !expenseRange?.from ||
+        !expenseRange?.to ||
+        !incomeRange?.from ||
+        !incomeRange?.to
+      ) {
+        return;
+      }
       try {
-        const data = await listRecentTransactions();
+        const start =
+          expenseRange.from < incomeRange.from
+            ? expenseRange.from
+            : incomeRange.from;
+        const end =
+          expenseRange.to > incomeRange.to ? expenseRange.to : incomeRange.to;
+        const data = await listRecentTransactions(
+          start.toISOString().slice(0, 10),
+          end.toISOString().slice(0, 10),
+        );
         setRecentTransaction(data);
       } catch (error) {
         console.error('Erro ao carregar os dados:', error);
@@ -27,7 +46,7 @@ export default function TransactionsCard() {
     };
 
     fetchTransactions();
-  }, []);
+  }, [expenseRange, incomeRange]);
   return (
     <div>
       <Card className="h-[400px]">

--- a/src/features/income/components/IncomePage.tsx
+++ b/src/features/income/components/IncomePage.tsx
@@ -48,7 +48,7 @@ const IncomePage = () => {
       ) : (
         <div>
           <div className="text-right">
-            <CreateForm onIncomeCreated={reloadIncomes} />
+            <CreateForm />
           </div>
           <DataTable
             columns={columns}

--- a/src/features/objective/components/ObjectiveEditForm.tsx
+++ b/src/features/objective/components/ObjectiveEditForm.tsx
@@ -96,7 +96,7 @@ export default function EditForm({
               <FormField
                 control={form.control}
                 name="objective"
-              render={() => (
+                render={({ field }) => (
                   <FormItem>
                     <FormLabel>Objetivo</FormLabel>
                     <FormControl>
@@ -112,7 +112,7 @@ export default function EditForm({
               <FormField
                 control={form.control}
                 name="description"
-              render={() => (
+                render={({ field }) => (
                   <FormItem>
                     <FormLabel>Descrição</FormLabel>
                     <FormControl>


### PR DESCRIPTION
## Summary
- add a context to store home page date ranges
- use the new provider on the home page
- make `CalendarRange` controlled via props
- use selected ranges when fetching home data

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875912fa0ec8320b8bce7eb487cd308