### PR TITLE
Ensure stable React Query client across layout renders

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { MainLayout } from '@/layouts/MainLayout';
 import { usePathname } from 'next/navigation';
 import { Toaster } from '@/components/ui/toaster';
 import { ThemeProvider } from '@/components/common/theme-provider';
+import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 export default function RootLayout({
   children,
@@ -18,7 +19,7 @@ export default function RootLayout({
 
   const isExcluded = excludedRoutes.includes(pathname);
 
-  const queryClient = new QueryClient();
+  const [queryClient] = React.useState(() => new QueryClient());
   return (
     <html lang="en" suppressHydrationWarning>
       <body>


### PR DESCRIPTION
## Summary
- Instantiate React Query's `QueryClient` once in `RootLayout` using `React.useState`
- Provide the stable `queryClient` instance to `QueryClientProvider` so mutations like creating objectives invalidate and refetch queries automatically

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a7937fec88320b1ede8cfe6543b78